### PR TITLE
Add town field to BeginLocation and EndLocation data frames

### DIFF
--- a/create-feed/massdot.md
+++ b/create-feed/massdot.md
@@ -10,8 +10,8 @@ Tag | Value
 Identifier | 137097
 StartDateTime<ul><li>startDateTime-ver</li></ul> | startDateTime-ver: 2016-11-03T19:37:00
 EndDateTime<ul><li>endDateTime-est</li></ul> | endDateTime-est: 2016-11-04T05:30:00
-BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399<br>town: Northampton
-EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>town: Northampton
+BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li><li>jurisdiction</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399<br>jurisdiction: Northampton
+EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li><li>jurisdiction</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>jurisdiction: Northampton
 wz-Status | active
 totalLanes | 3
 openLanes | right2
@@ -41,12 +41,12 @@ timeStampEventUpdate | 2017-11-02T18:57:02
 		<roadDirection>southbound</roadDirection>
 		<latitude-est>42.33865</latitude-est>
 		<longitude-est>-72.63399</longitude-est>
-		<town>Northampton</town>
+		<jurisdiction>Northampton</jurisdiction>
 	</beginLocation>
 	<endLocation>
 		<latitude-est>42.33307</latitude-est>
 		<longitude-est>-72.6214</longitude-est>
-		<town>Northampton</town>
+		<jurisdiction>Northampton</jurisdiction>
 	</endLocation>
 	<wz_status>active</wz_status>
 	<totalLanes>3</totalLanes>
@@ -81,12 +81,12 @@ timeStampEventUpdate | 2017-11-02T18:57:02
             "roadDirection": "southtbound",
             "latitude-est": 42.33865,
             "longitude-est": -72.63399,
-            "town": "Northampton"
+            "jurisdiction": "Northampton"
          },
          "endLocation": {
             "latitude-est": 42.33307,
             "longitude-est": -72.6214,
-            "town": "Northampton"
+            "jurisdiction": "Northampton"
          },
          "wz_status": "active",
          "totalLanes": "3",

--- a/create-feed/massdot.md
+++ b/create-feed/massdot.md
@@ -55,7 +55,7 @@ timeStampEventUpdate | 2017-11-02T18:57:02
 	<closedShoulders>inside</closedShoulders>
 	<workersPresent>n/a</workersPresent>
 	<roadRestrictions>n/a</roadRestrictions>
-	<description>I-91 Southbound Exit (20) Rt-5/Rt-10 Northhampton Hadley to Exit (19) Rt-9</description>
+	<description>I-91 Southbound Exit (20) Rt-5/Rt-10 Northampton Hadley to Exit (19) Rt-9</description>
 	<issuingOrganization>MassDOT</issuingOrganization>
 	<timestampEventUpdate>2017-11-02T18:57:02</timestampEventUpdate>
 </WorkZoneActivity>
@@ -95,7 +95,7 @@ timeStampEventUpdate | 2017-11-02T18:57:02
          "closedShoulders": "inside",
          "workersPresent": "n/a",
          "roadRestrictions": "n/a",
-         "description": "I-91 Southbound Exit (20) Rt-5/Rt-10 Northhampton Hadley to Exit (19) Rt-9",
+         "description": "I-91 Southbound Exit (20) Rt-5/Rt-10 Northampton Hadley to Exit (19) Rt-9",
          "issuingOrganization": "MassDOT",
          "timestampEventUpdate": "2017-11-02T18:57:02"
       },

--- a/create-feed/massdot.md
+++ b/create-feed/massdot.md
@@ -10,8 +10,8 @@ Tag | Value
 Identifier | 137097
 StartDateTime<ul><li>startDateTime-ver</li></ul> | startDateTime-ver: 2016-11-03T19:37:00
 EndDateTime<ul><li>endDateTime-est</li></ul> | endDateTime-est: 2016-11-04T05:30:00
-BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399
-EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214
+BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399<br>town: Northampton
+EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>town: Northampton
 wz-Status | active
 totalLanes | 3
 openLanes | right2
@@ -41,10 +41,12 @@ timeStampEventUpdate | 2017-11-02T18:57:02
 		<roadDirection>southbound</roadDirection>
 		<latitude-est>42.33865</latitude-est>
 		<longitude-est>-72.63399</longitude-est>
+		<town>Northampton</town>
 	</beginLocation>
 	<endLocation>
 		<latitude-est>42.33307</latitude-est>
 		<longitude-est>-72.6214</longitude-est>
+		<town>Northampton</town>
 	</endLocation>
 	<wz_status>active</wz_status>
 	<totalLanes>3</totalLanes>
@@ -79,10 +81,12 @@ timeStampEventUpdate | 2017-11-02T18:57:02
             "roadDirection": "southtbound",
             "latitude-est": 42.33865,
             "longitude-est": -72.63399,
+            "town": "Northampton"
          },
          "endLocation": {
             "latitude-est": 42.33307,
             "longitude-est": -72.6214,
+            "town": "Northampton"
          },
          "wz_status": "active",
          "totalLanes": "3",

--- a/data-tables/data-frames.md
+++ b/data-tables/data-frames.md
@@ -43,7 +43,7 @@ Data | Data Description | Conformance | Notes
 **milepost-est** | The estimated linear distance<br>measured against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | A milepost or mile marker is<br>a surveyed distance posted<br>along a roadway measuring<br>the length (in miles or tenth<br>of a mile) from the south<br>west to the north east. <br>These markers are typically<br>notated on State and local<br>government digital road<br>networks. Provide link to<br>description of milepost<br>method in metadata file<br>(see Section 2.7).
 **milepost-ver** | An accurately linear distance<br>measured against a milepost<br>marker along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along the<br>roadway where the work zone<br>area begins | Conditional | Required when Road<br>Classification is arterial
-**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte
+**jurisdiction** | The jurisdiction (town, city, etc.) where the the work zone begins | Optional | Examples: Boston, Charlotte
 
 ## EndLocation
 **Definition:** The LOCATION along a single road in a single direction when work zone impact ends and the traffic returns to normal. Provide method for describing “impact” in metadata file (see Section 2.7)
@@ -58,4 +58,4 @@ Data Name | Data Description | Conformance | Notes
 **milepost-est** | The measured linear distance<br>along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | Provide link to description<br>of milepost method in<br>metadata file (see Section 2.7)
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
-**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte
+**jurisdiction** | The jurisdiction (town, city, etc.) where the the work zone ends | Optional | Examples: Boston, Charlotte

--- a/data-tables/data-frames.md
+++ b/data-tables/data-frames.md
@@ -43,6 +43,7 @@ Data | Data Description | Conformance | Notes
 **milepost-est** | The estimated linear distance<br>measured against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | A milepost or mile marker is<br>a surveyed distance posted<br>along a roadway measuring<br>the length (in miles or tenth<br>of a mile) from the south<br>west to the north east. <br>These markers are typically<br>notated on State and local<br>government digital road<br>networks. Provide link to<br>description of milepost<br>method in metadata file<br>(see Section 2.7).
 **milepost-ver** | An accurately linear distance<br>measured against a milepost<br>marker along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along the<br>roadway where the work zone<br>area begins | Conditional | Required when Road<br>Classification is arterial
+**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte
 
 ## EndLocation
 **Definition:** The LOCATION along a single road in a single direction when work zone impact ends and the traffic returns to normal. Provide method for describing “impact” in metadata file (see Section 2.7)
@@ -57,3 +58,4 @@ Data Name | Data Description | Conformance | Notes
 **milepost-est** | The measured linear distance<br>along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | Provide link to description<br>of milepost method in<br>metadata file (see Section 2.7)
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
+**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte

--- a/full-spec/full-spec.md
+++ b/full-spec/full-spec.md
@@ -430,8 +430,8 @@ Tag | Value
 Identifier | 137097
 StartDateTime<ul><li>startDateTime-ver</li></ul> | startDateTime-ver: 2016-11-03T19:37:00
 EndDateTime<ul><li>endDateTime-est</li></ul> | endDateTime-est: 2016-11-04T05:30:00
-BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399
-EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214
+BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399<br>town: Northampton
+EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>town: Northampton
 wz-Status | active
 totalLanes | 3
 openLanes | right2

--- a/full-spec/full-spec.md
+++ b/full-spec/full-spec.md
@@ -188,7 +188,7 @@ Data | Data Description | Conformance | Notes
 **milepost-est** | The estimated linear distance<br>measured against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | A milepost or mile marker is<br>a surveyed distance posted<br>along a roadway measuring<br>the length (in miles or tenth<br>of a mile) from the south<br>west to the north east. <br>These markers are typically<br>notated on State and local<br>government digital road<br>networks. Provide link to<br>description of milepost<br>method in metadata file<br>(see Section 2.7).
 **milepost-ver** | An accurately linear distance<br>measured against a milepost<br>marker along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along the<br>roadway where the work zone<br>area begins | Conditional | Required when Road<br>Classification is arterial
-**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte
+**jurisdiction** | The jurisdiction (town, city, etc.) where the the work zone begins | Optional | Examples: Boston, Charlotte
 
 #### EndLocation
 Definition: The LOCATION along a single road in a single direction when work zone impact ends and the traffic returns to normal. Provide method for describing “impact” in metadata file (see Section 2.7)
@@ -203,7 +203,7 @@ Data Name | Data Description | Conformance | Notes
 **milepost-est** | The measured linear distance<br>along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | Provide link to description<br>of milepost method in<br>metadata file (see Section 2.7)
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
-**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte
+**jurisdiction** | The jurisdiction (town, city, etc.) where the the work zone ends | Optional | Examples: Boston, Charlotte
 
 ### Enumerated Types
 #### Table 7. Enumerated Types Table
@@ -430,8 +430,8 @@ Tag | Value
 Identifier | 137097
 StartDateTime<ul><li>startDateTime-ver</li></ul> | startDateTime-ver: 2016-11-03T19:37:00
 EndDateTime<ul><li>endDateTime-est</li></ul> | endDateTime-est: 2016-11-04T05:30:00
-BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399<br>town: Northampton
-EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>town: Northampton
+BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li><li>jurisdiction</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399<br>jurisdiction: Northampton
+EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li><li>jurisdiction</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>jurisdiction: Northampton
 wz-Status | active
 totalLanes | 3
 openLanes | right2

--- a/full-spec/full-spec.md
+++ b/full-spec/full-spec.md
@@ -188,6 +188,7 @@ Data | Data Description | Conformance | Notes
 **milepost-est** | The estimated linear distance<br>measured against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | A milepost or mile marker is<br>a surveyed distance posted<br>along a roadway measuring<br>the length (in miles or tenth<br>of a mile) from the south<br>west to the north east. <br>These markers are typically<br>notated on State and local<br>government digital road<br>networks. Provide link to<br>description of milepost<br>method in metadata file<br>(see Section 2.7).
 **milepost-ver** | An accurately linear distance<br>measured against a milepost<br>marker along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along the<br>roadway where the work zone<br>area begins | Conditional | Required when Road<br>Classification is arterial
+**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte
 
 #### EndLocation
 Definition: The LOCATION along a single road in a single direction when work zone impact ends and the traffic returns to normal. Provide method for describing “impact” in metadata file (see Section 2.7)
@@ -202,6 +203,7 @@ Data Name | Data Description | Conformance | Notes
 **milepost-est** | The measured linear distance<br>along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | Provide link to description<br>of milepost method in<br>metadata file (see Section 2.7)
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
+**town** | The town or city where the the work zone beings | Optional | Examples: Boston, Charlotte
 
 ### Enumerated Types
 #### Table 7. Enumerated Types Table

--- a/full-spec/full-spec.md
+++ b/full-spec/full-spec.md
@@ -431,7 +431,7 @@ Identifier | 137097
 StartDateTime<ul><li>startDateTime-ver</li></ul> | startDateTime-ver: 2016-11-03T19:37:00
 EndDateTime<ul><li>endDateTime-est</li></ul> | endDateTime-est: 2016-11-04T05:30:00
 BeginLocation<ul><li>roadName</li><li>roadNum</li><li>roadDirection</li><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | roadName: I-91<br>roadDirection: southbound<br>latitude-est: 42.33865<br>longitude-est: -72.63399<br>town: Northampton
-EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>town: Northampton
+EndLocation<ul><li>latitude</li><li>longitude</li><li>milepost</li><li>town</li></ul> | latitude-est: 42.33307<br>longitude-est: -72.6214<br>town: Northampton
 wz-Status | active
 totalLanes | 3
 openLanes | right2


### PR DESCRIPTION
## Issue
Currently, there is no notion of the town/city anywhere in the specification. I'm part of a team working with MassDOT, and we believe town (as the general term; also encompasses city) would be beneficial information about a work zone to include in our data feed. Since the work zone activity may span multiple towns, the `town` field should be added to the `BeginLocation` and `EndLocation` data frames individually rather than the common core data.

## Proposal
I've updated the `BeginLocation` and `EndLocation` data frames to include a `town` field. For flexibility and backward compatibility, this field is optional.

The field name *"town"* was chosen over *"city"* as we felt it was a more general term and more familiar to MassDOT. If other DOTs/entities have comments about the naming of this field or if there are other standards and we can come to a different consensus, I will gladly update the PR.

## Examples and Current Use
I updated the MassDOT examples to show the `town` field in use. The other examples are still valid as the `town` field is optional.
