### PR TITLE
Add support for location geometry

### DIFF
--- a/data-tables/data-frames.md
+++ b/data-tables/data-frames.md
@@ -57,3 +57,12 @@ Data Name | Data Description | Conformance | Notes
 **milepost-est** | The measured linear distance<br>along a roadway where the<br>work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) | Provide link to description<br>of milepost method in<br>metadata file (see Section 2.7)
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
+
+#### Location Geometry
+This represents the location geometry of the full work zone.
+
+#### Table 7. Location Geometry Data Frame Table
+Data Name | Data Description | Conformance | Notes
+--------- | ---------------- | ----------- | -----
+**linestring-est** | The LineString representing the full length of the estimated work zone area, with 6 digits after the decimal point for accuracy. <br /> | Conditional<ul><li>linestring-est or</li><li>linestring-ver</li></ul> | A series of space-delimited lat long pairs, ex: "51.510090 -0.006902 51.509142 -0.006564" |
+**linestring-ver** | The LineString representing the full length of the estimated work zone area, with 6 digits after the decimal point for accuracy. <br /> | Conditional<ul><li>linestring-est or</li><li>linestring-ver</li></ul> | A series of space-delimited lat long pairs, ex: "51.510090 -0.006902 51.509142 -0.006564" |

--- a/data-tables/data-frames.md
+++ b/data-tables/data-frames.md
@@ -58,10 +58,10 @@ Data Name | Data Description | Conformance | Notes
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
 
-#### Location Geometry
+#### LocationGeometry
 This represents the location geometry of the full work zone.
 
-#### Table 7. Location Geometry Data Frame Table
+#### Table 7. LocationGeometry Data Frame Table
 Data Name | Data Description | Conformance | Notes
 --------- | ---------------- | ----------- | -----
 **linestring-est** | The LineString representing the full length of the estimated work zone area, with 6 digits after the decimal point for accuracy. <br /> | Conditional<ul><li>linestring-est or</li><li>linestring-ver</li></ul> | A series of space-delimited lat long pairs, ex: "51.510090 -0.006902 51.509142 -0.006564" |

--- a/full-spec/full-spec.md
+++ b/full-spec/full-spec.md
@@ -92,6 +92,7 @@ The remainder of this document is organized into the following sections:
     - EndDateTime
     - BeginLocation
     - EndLocation
+    - Location Geometry
 - **Enumerated Types** - This section includes a table of enumerated data elements.
 - **Enumerated Type Definitions** - This section includes definitions for enumerated types including work zone status, status of Time and Location, and Road Restrictions. 
 - **Metadata** - This section describes the contents of a static file with information about the quality and context of data in the data feed. 
@@ -123,6 +124,7 @@ Data Name | Data Type | Data Description | Conformance | Notes
 **EndDateTime** | Data Frame | The time and date when a work zone<br>ends | Required | 
 **BeginLocation** | Data Frame | The LOCATION when work zone<br>impact begins along a single road in<br>a single direction (see<br>BeginLocation).The impact typically<br>begins where the first channeling<br>device (e.g., cone or barrel) is<br>located. | Required | The method used for<br>designating impact<br>should be included in a<br>static Metadata file (see<br>Section 2.7)
 **EndLocation** | Data Frame | The LOCATION along a single road<br>in a single direction when work zone<br>impact ends and the traffic returns to<br>normal (See EndLocation) | Required | The method used for<br>designating impact<br>should be included in a<br>static Metadata file (see Section 2.7)
+**Location Geometry** | Data Frame | The LOCATION GEOMETRY along a single road<br>in a single direction from where it starts through where it ends, and all points in between (See LocationGeometry) | Required | 
 **wz-Status** | Enum | The status of the work zone | Optional | See Enumerated Type Definitions
 **totalLanes** | Data element | The total number of lanes associated<br>with the road segment designated by<br>the BeginLocation and EndLocation | Optional | A segment is a part of a<br>roadway in a single<br>direction designated by<br>a start (BeginLocation)<br>and end (EndLocation)
 **openLanes** | Enum | The laneType that is opened on the road segment<br>designated by<br>the work zone BeginLocation | Optional |

--- a/full-spec/full-spec.md
+++ b/full-spec/full-spec.md
@@ -18,6 +18,7 @@ Updated 9/15/2018
        - [EndDateTime](#enddatetime)
        - [BeginLocation](#beginlocation)
        - [EndLocation](#endlocation)
+       - [Location Geometry](#locationgeometry)
     - [Enumerated Types](#enumerated-types)
     - [Enumerated Type Definitions](#enumerated-type-definitions)
     - [Enumerated Value Definitions Derived from ITS Standards](#enumerated-value-definitions-derived-from-its-standards)
@@ -43,11 +44,12 @@ Updated 9/15/2018
 - [Table 4 EndDateTime Data Frame Table](#table-4-enddatetime-data-frame-table)
 - [Table 5 BeginLocation Data Frame Table](#table-5-beginlocation-data-frame-table)
 - [Table 6 EndLocation Data Frame Table](#table-6-endlocation-data-frame-table)
-- [Table 7 Enumerated Types Table](#table-7-enumerated-types-table)
-- [Table 8 Work Zone Status Definition Table](#table-8-work-zone-status-definition-table)
-- [Table 9 Spatial and Time Verification Definitions](#table-9-spatial-and-time-verification-definitions)
-- [Table 10 RoadRestrictions Definitions](#table-10-roadrestrictions-definitions)
-- [Table 11 Metadata](#table-11-metadata)
+- [Table 7 Location Geometry Data Frame Table](#table-7-location-geometry-data-frame-table)
+- [Table 8 Enumerated Types Table](#table-8-enumerated-types-table)
+- [Table 9 Work Zone Status Definition Table](#table-9-work-zone-status-definition-table)
+- [Table 10 Spatial and Time Verification Definitions](#table-10-spatial-and-time-verification-definitions)
+- [Table 11 RoadRestrictions Definitions](#table-11-roadrestrictions-definitions)
+- [Table 12 Metadata](#table-12-metadata)
 - [Figure 1 Work Zone Activity Organization](#figure-1-work-zone-activity-organization)
 
 ## Introduction
@@ -203,8 +205,17 @@ Data Name | Data Description | Conformance | Notes
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
 
+#### Location Geometry
+This represents the location geometry of the full work zone.
+
+#### Table 7. Location Geometry Data Frame Table
+Data Name | Data Description | Conformance | Notes
+--------- | ---------------- | ----------- | -----
+**linestring-est** | The LineString representing the full length of the estimated work zone area, with 6 digits after the decimal point for accuracy. <br /> | Conditional<ul><li>linestring-est or</li><li>linestring-ver</li></ul> | A series of space-delimited lat long pairs, ex: "51.510090 -0.006902 51.509142 -0.006564" |
+**linestring-ver** | The LineString representing the full length of the estimated work zone area, with 6 digits after the decimal point for accuracy. <br /> | Conditional<ul><li>linestring-est or</li><li>linestring-ver</li></ul> | A series of space-delimited lat long pairs, ex: "51.510090 -0.006902 51.509142 -0.006564" |
+
 ### Enumerated Types
-#### Table 7. Enumerated Types Table
+#### Table 8. Enumerated Types Table
 Data Element | Used by | Allowed Values | Notes | Source
 ------------ | ------- | -------------- | ----- | ------
 **wz-Status** | WorkZoneActivity | See Enumerated Type<br>Definitions (Table 8) 
@@ -214,7 +225,7 @@ Data Element | Used by | Allowed Values | Notes | Source
 **closedShoulders** | WorkZoneActivity | <ul><li>outside</li><li>inside</li><li>both</li><li>none</li><li>unknown</li></ul> |  | Adapted from<br>TMDD<br>LaneRoadway
 
 ### Enumerated Type Definitions
-#### Table 8. Work Zone Status Definition Table
+#### Table 9. Work Zone Status Definition Table
 Term | WZ-Status Description
 ---- | ---------------------
 **Planned** | Planned status is associated with overall project or phase timing and locations.<br>Typically, this information is estimated during planning or early design phases. The<br>WZDx will not generally include planned activities.
@@ -223,7 +234,7 @@ Term | WZ-Status Description
 **Cancelled** | Reported cancellation of a proposed or active WZ; the coverage applies to the work zone activity record.<ul><li>When date/time is estimated, the cancellation may be one or more days<br>associated within the reported scheduled datetimes</li></ul>
 **Completed** | Work Zone is closed and completed; all work zone impacts are mitigated. This status<br>may be used when a work zone activity is completed earlier than expected.
 
-#### Table 9. Spatial and Time Verification Definitions
+#### Table 10. Spatial and Time Verification Definitions
 Term | WZ-Status Description
 ---- | ---------------------
 **DateTime<br>Estimated(-est)** | Specific times/dates when work will or is occurring; includes advanced notice of<br>activities or unverified work zone activities. This date/time may be reported in<br>advance, but is not actively verified on day of event.
@@ -231,7 +242,7 @@ Term | WZ-Status Description
 **Location<br>Estimated (-est)** | Estimated location associated with work zone activities and lane closures.<br>An estimated measurement may be based on an approximation of a location<br>referencing method (e.g., lat/long or milepost), for example: a point relative to a<br>posted milemarker, point on a map, or GPS device that provides less than<br>centimeter accuracy.
 **Location Verified<br>(-ver)** | Actual reported information about work zone locations. Actual location is<br>typically measured by a calibrated navigation or survey system to centimeter<br>accuracy (six decimal places for latitude and longitude).
 
-#### Table 10. RoadRestrictions Definitions
+#### Table 11. RoadRestrictions Definitions
 RoadRestrictions | Descriptions
 ---------------- | ------------
 **no-trucks** | Trucks are prohibited from traveling in work zone area

--- a/full-spec/full-spec.md
+++ b/full-spec/full-spec.md
@@ -18,7 +18,7 @@ Updated 9/15/2018
        - [EndDateTime](#enddatetime)
        - [BeginLocation](#beginlocation)
        - [EndLocation](#endlocation)
-       - [Location Geometry](#locationgeometry)
+       - [LocationGeometry](#locationgeometry)
     - [Enumerated Types](#enumerated-types)
     - [Enumerated Type Definitions](#enumerated-type-definitions)
     - [Enumerated Value Definitions Derived from ITS Standards](#enumerated-value-definitions-derived-from-its-standards)
@@ -44,7 +44,7 @@ Updated 9/15/2018
 - [Table 4 EndDateTime Data Frame Table](#table-4-enddatetime-data-frame-table)
 - [Table 5 BeginLocation Data Frame Table](#table-5-beginlocation-data-frame-table)
 - [Table 6 EndLocation Data Frame Table](#table-6-endlocation-data-frame-table)
-- [Table 7 Location Geometry Data Frame Table](#table-7-location-geometry-data-frame-table)
+- [Table 7 LocationGeometry Data Frame Table](#table-7-locationgeometry-data-frame-table)
 - [Table 8 Enumerated Types Table](#table-8-enumerated-types-table)
 - [Table 9 Work Zone Status Definition Table](#table-9-work-zone-status-definition-table)
 - [Table 10 Spatial and Time Verification Definitions](#table-10-spatial-and-time-verification-definitions)
@@ -92,7 +92,7 @@ The remainder of this document is organized into the following sections:
     - EndDateTime
     - BeginLocation
     - EndLocation
-    - Location Geometry
+    - LocationGeometry
 - **Enumerated Types** - This section includes a table of enumerated data elements.
 - **Enumerated Type Definitions** - This section includes definitions for enumerated types including work zone status, status of Time and Location, and Road Restrictions. 
 - **Metadata** - This section describes the contents of a static file with information about the quality and context of data in the data feed. 
@@ -124,7 +124,7 @@ Data Name | Data Type | Data Description | Conformance | Notes
 **EndDateTime** | Data Frame | The time and date when a work zone<br>ends | Required | 
 **BeginLocation** | Data Frame | The LOCATION when work zone<br>impact begins along a single road in<br>a single direction (see<br>BeginLocation).The impact typically<br>begins where the first channeling<br>device (e.g., cone or barrel) is<br>located. | Required | The method used for<br>designating impact<br>should be included in a<br>static Metadata file (see<br>Section 2.7)
 **EndLocation** | Data Frame | The LOCATION along a single road<br>in a single direction when work zone<br>impact ends and the traffic returns to<br>normal (See EndLocation) | Required | The method used for<br>designating impact<br>should be included in a<br>static Metadata file (see Section 2.7)
-**Location Geometry** | Data Frame | The LOCATION GEOMETRY along a single road<br>in a single direction from where it starts through where it ends, and all points in between (See LocationGeometry) | Required | 
+**LocationGeometry** | Data Frame | The LOCATION GEOMETRY along a single road<br>in a single direction from where it starts through where it ends, and all points in between (See LocationGeometry) | Required | 
 **wz-Status** | Enum | The status of the work zone | Optional | See Enumerated Type Definitions
 **totalLanes** | Data element | The total number of lanes associated<br>with the road segment designated by<br>the BeginLocation and EndLocation | Optional | A segment is a part of a<br>roadway in a single<br>direction designated by<br>a start (BeginLocation)<br>and end (EndLocation)
 **openLanes** | Enum | The laneType that is opened on the road segment<br>designated by<br>the work zone BeginLocation | Optional |
@@ -207,10 +207,10 @@ Data Name | Data Description | Conformance | Notes
 **milepost-ver** | An accurately linear distance measured<br>against a milepost<br>marker along a roadway where<br>the work zone begins | Optional<br><br>If included only<br>one milepost<br>value (-est or -ver<br>is needed) |  |
 **crossStreet** | The cross street along a<br>roadway where the work zone<br>area ends and the traffic returns<br>to normal | Conditional | Required when Road Classification is arterial
 
-#### Location Geometry
+#### LocationGeometry
 This represents the location geometry of the full work zone.
 
-#### Table 7. Location Geometry Data Frame Table
+#### Table 7. LocationGeometry Data Frame Table
 Data Name | Data Description | Conformance | Notes
 --------- | ---------------- | ----------- | -----
 **linestring-est** | The LineString representing the full length of the estimated work zone area, with 6 digits after the decimal point for accuracy. <br /> | Conditional<ul><li>linestring-est or</li><li>linestring-ver</li></ul> | A series of space-delimited lat long pairs, ex: "51.510090 -0.006902 51.509142 -0.006564" |


### PR DESCRIPTION
### Issue

The `BeginLocation` and `EndLocation` data frames do not adequately capture the location of work zones for use in navigation/routing applications. This is because the exact geometry of the closure cannot be determined easily with only one lat-long pair.

### Proposal

This PR adds a new item to the common core data dictionary a data frame `LocationGeometry` that includes two fields:
- `linestring-est`
- `linestring-ver`

Both fields are a series of space-delimited lat-long pairs representing the full length of the work zone, ex: "51.510090 -0.006902 51.509142 -0.006564". This is in addition to `BeginLocation` and `EndLocation`, which remain as-is. `-est` and `-ver` stands for estimated and verified respectively, following the convention already established in the WZDx spec.

#### Note

A previous pull request was opened (#23) to conform the WZDx to the GeoJSON spec (as per #21), but it was backwards-incompatible. This PR, however, is backwards-compatible in the `LocationGeometry` can be added in and ignored if desired.

### Edit:
Just a quick note on the use of a linestring/polyline to represent the location geometry:

My thinking was that this would be the simplest way to include work zone geometry within the existing WZDx feed, which is built to be complaint with XML. Embedding GeoJSON within XML would require using something like GML/KML, and I thought this approach was simpler.