### PR TITLE
Fixed typos in linestring and multipoint examples

### DIFF
--- a/create-feed/examples/linestring_example.geojson
+++ b/create-feed/examples/linestring_example.geojson
@@ -37,7 +37,7 @@
         "types_of_work": [
           {
             "type_name": "painting",
-            "is_architectual_change": false
+            "is_architectural_change": false
           }
         ],
         "lanes": [
@@ -241,7 +241,7 @@
        "subidentifier": "State_Project_002",
        "road_name": "Barrett Street",
        "road_number": "I-200",
-       "direction": "west bound",
+       "direction": "westbound",
        "beginning_cross_street": "King St",
        "ending_cross_street": "Hampton Garden Dr",
        "beginning_milepost": 120.10,
@@ -265,7 +265,7 @@
        "types_of_work": [
          {
            "type_name": "roadside-work",
-           "is_architectual_change": false
+           "is_architectural_change": false
          }
        ],
        "lanes": [

--- a/create-feed/examples/multipoint_example.geojson
+++ b/create-feed/examples/multipoint_example.geojson
@@ -37,7 +37,7 @@
         "types_of_work": [
           {
             "type_name": "painting",
-            "is_architectual_change": false
+            "is_architectural_change": false
           }
         ],
         "lanes": [
@@ -89,7 +89,7 @@
        "subidentifier": "State_Project_002",
        "road_name": "Barrett Street",
        "road_number": "I-200",
-       "direction": "west bound",
+       "direction": "westbound",
        "beginning_cross_street": "King St",
        "ending_cross_street": "Hampton Garden Drive",
        "beginning_milepost": 120.10,
@@ -113,7 +113,7 @@
        "types_of_work": [
          {
            "type_name": "roadside-work",
-           "is_architectual_change": false
+           "is_architectural_change": false
          }
        ],
        "lanes": [


### PR DESCRIPTION
Updated the example GeoJSON files, with the following changes:

- `is_architectual_change` to `is_architectural_change` (per [types_of_work.md](https://github.com/usdot-jpo-ode/jpo-wzdx/blob/aaf65e60efa5bd09feecabec05ca8652bbc20e57/feed-content/data-tables/types_of_work.md)). 
- "west bound" direction to "westbound" (per [direction.md](https://github.com/usdot-jpo-ode/jpo-wzdx/blob/aaf65e60efa5bd09feecabec05ca8652bbc20e57/feed-content/enumerated-types/derived-from-its-standards/direction.md))