### PR TITLE
Remove last update line from project root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 This repository contains the Work Zone Data Exchange (WZDx) Specification.
 
->Last updated 9/3/2020 - WZDx Specification v3.0
-
 The WZDx Specification repository contains two main subdirectories, each containing their own README file with additional information about the purpose and files within:
 
 


### PR DESCRIPTION
This PR removes the following line from the project root README:

> Last updated 9/3/2020 - WZDx Specification v3.0

The change was made for the following reasons:

- The line is unnecessary—one can readily see via the GitHub web UI when the repo and every specific file was last updated
- The line has not been updated consistently when changes were made
- It is not clear what updates would warrant updating the line
- One can check both the Releases section of the right pane on GitHub and the `RELEASES.md` file and the most current release 
