### PR TITLE
Add local-access-only restriction

### DIFF
--- a/create-feed/schemas/wzdx_vNext_feed.json
+++ b/create-feed/schemas/wzdx_vNext_feed.json
@@ -428,7 +428,7 @@
     "VehicleImpact": {
       "title": "Vehicle Impact Enumerated Type",
       "description": "The impact to vehicular lanes along a single road in a single direction",
-      "enum": ["all-lanes-closed", "some-lanes-closed", "all-lanes-open", "alternating-one-way", "unknown"]
+      "enum": ["all-lanes-closed", "some-lanes-closed", "all-lanes-open", "alternating-one-way", "local-access-only", "unknown"]
     },
     "RoadRestriction": {
       "title": "Road Restriction Enumerated Type",
@@ -446,7 +446,8 @@
         "axle-load-limit",
         "gross-weight-limit",
         "towing-prohibited",
-        "permitted-oversize-loads-prohibited"
+        "permitted-oversize-loads-prohibited",
+        "local-access-only"
       ]
     },
     "WorkTypeName": {

--- a/create-feed/schemas/wzdx_vNext_feed.json
+++ b/create-feed/schemas/wzdx_vNext_feed.json
@@ -428,7 +428,7 @@
     "VehicleImpact": {
       "title": "Vehicle Impact Enumerated Type",
       "description": "The impact to vehicular lanes along a single road in a single direction",
-      "enum": ["all-lanes-closed", "some-lanes-closed", "all-lanes-open", "alternating-one-way", "local-access-only", "unknown"]
+      "enum": ["all-lanes-closed", "some-lanes-closed", "all-lanes-open", "alternating-one-way", "unknown"]
     },
     "RoadRestriction": {
       "title": "Road Restriction Enumerated Type",

--- a/spec-content/enumerated-types/RoadRestriction.md
+++ b/spec-content/enumerated-types/RoadRestriction.md
@@ -4,6 +4,7 @@ The type of vehicle restriction on a roadway.
 ## Values
 Value | Description
 --- | ---
+'local-access-only' | Travel allowed only for vehicles accessing addresses in the work zone area; this includes emergency services, deliveries, and direct property access
 `no-trucks` | Trucks are prohibited from traveling in work zone area
 `travel-peak-hours-only` | Travel restricted to travel peak hours only
 `hov-3` | Travel restricted to high occupancy vehicles of three or more

--- a/spec-content/enumerated-types/RoadRestriction.md
+++ b/spec-content/enumerated-types/RoadRestriction.md
@@ -4,7 +4,7 @@ The type of vehicle restriction on a roadway.
 ## Values
 Value | Description
 --- | ---
-'local-access-only' | Travel allowed only for vehicles accessing addresses in the work zone area; this includes emergency services, deliveries, and direct property access
+`local-access-only` | Travel allowed only for vehicles accessing addresses in the work zone area; this includes emergency services, deliveries, and direct property access
 `no-trucks` | Trucks are prohibited from traveling in work zone area
 `travel-peak-hours-only` | Travel restricted to travel peak hours only
 `hov-3` | Travel restricted to high occupancy vehicles of three or more

--- a/spec-content/enumerated-types/VehicleImpact.md
+++ b/spec-content/enumerated-types/VehicleImpact.md
@@ -8,6 +8,7 @@ Value | Description
 `some-lanes-closed` | Some lanes are closed
 `all-lanes-open` | All lanes are open
 `alternating-one-way` | The roadway is alternating one way
+'local-access-only' | The roadway is closed except for access to addresses within the closure
 `unknown` | The vehicle impact is unknown
 
 ## Used By

--- a/spec-content/enumerated-types/VehicleImpact.md
+++ b/spec-content/enumerated-types/VehicleImpact.md
@@ -8,7 +8,6 @@ Value | Description
 `some-lanes-closed` | Some lanes are closed
 `all-lanes-open` | All lanes are open
 `alternating-one-way` | The roadway is alternating one way
-'local-access-only' | The roadway is closed except for access to addresses within the closure
 `unknown` | The vehicle impact is unknown
 
 ## Used By


### PR DESCRIPTION
This PR resolves Issue #86 

Actions taken by this PR include:

- Add a new enumerated value of `local-access-only` to RoadRestriction

This will be used to denote that the only travel allowed in the extent of the RoadEvent is for direct access to addresses located within the extent of the RoadEvent; no through travel is allowed.