### PR TITLE
Clean up HTML tag in a value of the RoadRestriction enumerated type in the spec

### DIFF
--- a/spec-content/enumerated-types/RoadRestriction.md
+++ b/spec-content/enumerated-types/RoadRestriction.md
@@ -16,7 +16,7 @@ Value | Description
 `axle-load-limit` | Vehicle axle-load-limit restrictions reduced in work zone area
 `gross-weight-limit` | Vehicle gross-weight-limit restrictions reduced in work zone area
 `towing-prohibited` | Towing prohibited in work zone area
-`permitted-oversize-loads-<br>prohibited` | “Permitted oversize loads” prohibited in work zone area; this applies<br>to annual oversize load permits.
+`permitted-oversize-loads-prohibited` | “Permitted oversize loads” prohibited in work zone area; this applies<br>to annual oversize load permits.
 
 ## Used By
 Property | Object


### PR DESCRIPTION
I noticed there was a leftover \<br> tag in the enumerated value table that shouldn't be there. Since it's part of the value field, it would show up as text and not formatted as a new line as it does in the description part.